### PR TITLE
Add list ID to list table

### DIFF
--- a/src/templates/includes/lists.twig
+++ b/src/templates/includes/lists.twig
@@ -17,6 +17,7 @@
         <thead>
           <tr>
             <th scope="col">List</th>
+            <th scope="col">List ID</th>
             <th scope="col">Subscribers</th>
             <th scope="col">Unsubscribes</th>
             <th scope="col">Opens</th>
@@ -41,6 +42,9 @@
                 </a>
                 <div class="light">Created {{ created }}</div>
               </th>
+              <td class="nowrap">
+                <div class="light">{{ list.id }}</div>
+              </td>
               <td class="nowrap">
                 <div><code>{{ list.stats.member_count }}</code></div>
               </td>
@@ -93,3 +97,4 @@
   {% endif %}
 
 {% endif %}
+


### PR DESCRIPTION
Small addition of a column in the lists table that shows the list ID. I know that you could get the ID from going into the list's view and then copying from the URL but it's not massively intuitive, and seeing as the ID is going to quite likely be used elsewhere (such as in another entry) it makes sense to make it close to hand and easy to copy and paste.

Let me know if you agree!

Thanks
Matt