### PR TITLE
The plugin could be installed from the CLI

### DIFF
--- a/src/MailchimpLists.php
+++ b/src/MailchimpLists.php
@@ -86,16 +86,6 @@ class MailchimpLists extends Plugin
             }
         );
 
-        Event::on(
-            Plugins::class,
-            Plugins::EVENT_AFTER_INSTALL_PLUGIN,
-            function (PluginEvent $event) {
-                if ($event->plugin === $this) {
-                  Craft::$app->getResponse()->redirect(UrlHelper::cpUrl('settings/plugins/mailchimp-lists'))->send();
-                }
-            }
-        );
-
         Craft::info(
             Craft::t(
                 'mailchimp-lists',


### PR DESCRIPTION
Redirects will not work from CLI. e.g `./craft install/plugin mailchimp-lists`